### PR TITLE
cowork: Link UI

### DIFF
--- a/gno.land/pkg/gnoweb/app_test.go
+++ b/gno.land/pkg/gnoweb/app_test.go
@@ -15,9 +15,10 @@ import (
 
 func TestRoutes(t *testing.T) {
 	const (
-		ok       = http.StatusOK
-		found    = http.StatusFound
-		notFound = http.StatusNotFound
+		ok         = http.StatusOK
+		found      = http.StatusFound
+		notFound   = http.StatusNotFound
+		BadRequest = http.StatusBadRequest
 	)
 	routes := []struct {
 		route     string
@@ -49,7 +50,7 @@ func TestRoutes(t *testing.T) {
 		{"/blog", found, "/r/gnoland/blog"},
 		{"/r/docs/optional_render", http.StatusOK, "No Render"},
 		{"/r/not/found/", notFound, ""},
-		{"/404/not/found", notFound, ""},
+		{"/z/bad/request", BadRequest, ""}, // not realm or pure
 		{"/아스키문자가아닌경로", notFound, ""},
 		{"/%ED%85%8C%EC%8A%A4%ED%8A%B8", notFound, ""},
 		{"/グノー", notFound, ""},

--- a/gno.land/pkg/gnoweb/handler.go
+++ b/gno.land/pkg/gnoweb/handler.go
@@ -107,9 +107,9 @@ func (h *WebHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 // prepareIndexBodyView prepares the data and main view for the index.
 func (h *WebHandler) prepareIndexBodyView(r *http.Request, indexData *components.IndexData) (int, *components.View) {
-	gnourl, err := weburl.ParseGnoURL(r.URL, h.Static.Domain)
-	if err != nil {
-		h.Logger.Warn("unable to parse url path", "path", r.URL.Path, "error", err)
+	gnourl, err := weburl.ParseFromURL(r.URL)
+	if err != nil || !gnourl.IsValid() {
+		h.Logger.Warn("invalid gno url path", "path", r.URL.Path, "error", err)
 		return http.StatusNotFound, components.StatusErrorComponent("invalid path")
 	}
 
@@ -155,7 +155,7 @@ func (h *WebHandler) GetPackageView(gnourl *weburl.GnoURL) (int, *components.Vie
 func (h *WebHandler) GetRealmView(gnourl *weburl.GnoURL) (int, *components.View) {
 	var content bytes.Buffer
 
-	meta, err := h.Client.RenderRealm(&content, *gnourl)
+	meta, err := h.Client.RenderRealm(&content, gnourl)
 	if err != nil {
 		if errors.Is(err, ErrRenderNotDeclared) {
 			return http.StatusOK, components.StatusNoRenderComponent(gnourl.Path)

--- a/gno.land/pkg/gnoweb/handler.go
+++ b/gno.land/pkg/gnoweb/handler.go
@@ -108,7 +108,7 @@ func (h *WebHandler) Get(w http.ResponseWriter, r *http.Request) {
 // prepareIndexBodyView prepares the data and main view for the index.
 func (h *WebHandler) prepareIndexBodyView(r *http.Request, indexData *components.IndexData) (int, *components.View) {
 	gnourl, err := weburl.ParseFromURL(r.URL)
-	if err != nil || !gnourl.IsValidPath() {
+	if err != nil {
 		h.Logger.Warn("invalid gno url path", "path", r.URL.Path, "error", err)
 		return http.StatusNotFound, components.StatusErrorComponent("invalid path")
 	}

--- a/gno.land/pkg/gnoweb/handler.go
+++ b/gno.land/pkg/gnoweb/handler.go
@@ -108,7 +108,7 @@ func (h *WebHandler) Get(w http.ResponseWriter, r *http.Request) {
 // prepareIndexBodyView prepares the data and main view for the index.
 func (h *WebHandler) prepareIndexBodyView(r *http.Request, indexData *components.IndexData) (int, *components.View) {
 	gnourl, err := weburl.ParseFromURL(r.URL)
-	if err != nil || !gnourl.IsValid() {
+	if err != nil || !gnourl.IsValidPath() {
 		h.Logger.Warn("invalid gno url path", "path", r.URL.Path, "error", err)
 		return http.StatusNotFound, components.StatusErrorComponent("invalid path")
 	}

--- a/gno.land/pkg/gnoweb/markdown/ext.go
+++ b/gno.land/pkg/gnoweb/markdown/ext.go
@@ -39,9 +39,9 @@ import (
 var _ goldmark.Extender = (*gnoExtension)(nil)
 
 // NewGnoParserContext creates a new parser context with GnoURL
-func NewGnoParserContext(url weburl.GnoURL) parser.Context {
+func NewGnoParserContext(url *weburl.GnoURL) parser.Context {
 	ctx := parser.NewContext()
-	ctx.Set(gUrlContextKey, url)
+	ctx.Set(gUrlContextKey, *url)
 	return ctx
 }
 
@@ -53,17 +53,9 @@ func getUrlFromContext(ctx parser.Context) (url weburl.GnoURL, ok bool) {
 	return
 }
 
-// gnoExtension is a Goldmark extension that adds Gno-specific features
-type gnoExtension struct {
-	url weburl.GnoURL
-}
+type gnoExtension struct{}
 
-// NewGnoExtension creates a new Gno extension with the given URL
-func NewGnoExtension(url weburl.GnoURL) goldmark.Extender {
-	return &gnoExtension{
-		url: url,
-	}
-}
+var GnoExtension = &gnoExtension{}
 
 // Extend adds the Gno extension to the provided Goldmark markdown processor.
 func (e *gnoExtension) Extend(m goldmark.Markdown) {

--- a/gno.land/pkg/gnoweb/markdown/ext_links.go
+++ b/gno.land/pkg/gnoweb/markdown/ext_links.go
@@ -125,7 +125,7 @@ func (t *linkTransformer) Transform(doc *ast.Document, reader text.Reader, pc pa
 func detectLinkType(dest *url.URL, orig *weburl.GnoURL) (*weburl.GnoURL, GnoLinkType) {
 	// Attempt to parse the destination as a GnoURL.
 	target, err := weburl.ParseFromURL(dest)
-	if err != nil || !target.IsValidPath() {
+	if err != nil {
 		if dest.Scheme == "" {
 			// If there's no scheme, consider it as a relative path.
 			return nil, GnoLinkTypePackage

--- a/gno.land/pkg/gnoweb/markdown/ext_links.go
+++ b/gno.land/pkg/gnoweb/markdown/ext_links.go
@@ -3,6 +3,7 @@ package markdown
 import (
 	"errors"
 	"fmt"
+	"html"
 	"net/url"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoweb/weburl"
@@ -199,7 +200,7 @@ func (r *linkRenderer) renderGnoLink(w util.BufWriter, source []byte, node ast.N
 
 	if n.LinkType == GnoLinkTypeInvalid {
 		if entering {
-			fmt.Fprintf(w, "<!-- invalid link %q -->", n.Destination)
+			w.WriteString("<!-- invalid link -->")
 		}
 		return ast.WalkSkipChildren, nil
 	}
@@ -211,7 +212,7 @@ func (r *linkRenderer) renderGnoLink(w util.BufWriter, source []byte, node ast.N
 			attrs = append(attrs, attr{"rel", "noopener nofollow ugc"})
 		}
 		if n.Title != nil {
-			attrs = append(attrs, attr{"title", string(n.Title)})
+			attrs = append(attrs, attr{"title", html.EscapeString(string(n.Title))})
 		}
 
 		// Write opening tag <a>.

--- a/gno.land/pkg/gnoweb/markdown/ext_links.go
+++ b/gno.land/pkg/gnoweb/markdown/ext_links.go
@@ -3,7 +3,6 @@ package markdown
 import (
 	"errors"
 	"fmt"
-	"html"
 	"net/url"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoweb/weburl"
@@ -212,7 +211,7 @@ func (r *linkRenderer) renderGnoLink(w util.BufWriter, source []byte, node ast.N
 			attrs = append(attrs, attr{"rel", "noopener nofollow ugc"})
 		}
 		if n.Title != nil {
-			attrs = append(attrs, attr{"title", html.EscapeString(string(n.Title))})
+			attrs = append(attrs, attr{"title", string(n.Title)})
 		}
 
 		// Write opening tag <a>.

--- a/gno.land/pkg/gnoweb/markdown/ext_links.go
+++ b/gno.land/pkg/gnoweb/markdown/ext_links.go
@@ -125,11 +125,12 @@ func (t *linkTransformer) Transform(doc *ast.Document, reader text.Reader, pc pa
 func detectLinkType(dest *url.URL, orig *weburl.GnoURL) (*weburl.GnoURL, GnoLinkType) {
 	// Attempt to parse the destination as a GnoURL.
 	target, err := weburl.ParseFromURL(dest)
-	if err != nil {
+	if err != nil || !target.IsValidPath() {
 		if dest.Scheme == "" {
 			// If there's no scheme, consider it as a relative path.
 			return nil, GnoLinkTypePackage
 		}
+
 		// Otherwise, treat it as an external URL.
 		return nil, GnoLinkTypeExternal
 	}
@@ -262,6 +263,6 @@ func (l *linkExtension) Extend(m goldmark.Markdown) {
 
 	// Register our renderer with a higher priority than the default renderer
 	m.Renderer().AddOptions(renderer.WithNodeRenderers(
-		util.Prioritized(&linkRenderer{}, 500), // Priority 0 is higher than default
+		util.Prioritized(&linkRenderer{}, 500),
 	))
 }

--- a/gno.land/pkg/gnoweb/markdown/ext_links.go
+++ b/gno.land/pkg/gnoweb/markdown/ext_links.go
@@ -3,8 +3,9 @@ package markdown
 import (
 	"errors"
 	"fmt"
-	"strings"
+	"net/url"
 
+	"github.com/gnolang/gno/gno.land/pkg/gnoweb/weburl"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
@@ -12,6 +13,9 @@ import (
 	"github.com/yuin/goldmark/text"
 	"github.com/yuin/goldmark/util"
 )
+
+// Error messages for invalid link formats
+var ErrLinkInvalidURL = errors.New("invalid URL format")
 
 const (
 	// Tooltips info for link types
@@ -30,115 +34,129 @@ const (
 	classLinkTx       = "link-tx"
 )
 
-// LinkExtension is a Goldmark extension that handles link rendering with special attributes
-// for external, internal, and same-package links.
-type LinkExtension struct{}
+// GnoLinkType represents the type of a link
+type GnoLinkType int
 
-// LinkMetadata contains metadata about a GnoLink
-type LinkMetadata struct {
-	LinkType linkType
-	HasHelp  bool
+const (
+	GnoLinkTypeInvalid GnoLinkType = iota
+	GnoLinkTypeExternal
+	GnoLinkTypePackage
+	GnoLinkTypeInternal
+)
+
+func (t GnoLinkType) String() string {
+	switch t {
+	case GnoLinkTypeExternal:
+		return "external"
+	case GnoLinkTypePackage:
+		return "package"
+	case GnoLinkTypeInternal:
+		return "internal"
+	}
+	return "unknown"
 }
 
-// linkRenderer implements NodeRenderer
-type linkRenderer struct{}
+var KindGnoLink = ast.NewNodeKind("GnoLink")
 
 // GnoLink represents a link with Gno-specific metadata
 type GnoLink struct {
-	ast.Link
-	Metadata LinkMetadata
+	*ast.Link
+	LinkType GnoLinkType
+	GnoURL   *weburl.GnoURL
 }
 
-// linkType represents the type of a link
-type linkType int
+func (n *GnoLink) Dump(source []byte, level int) {
+	m := map[string]string{}
+	m["Destination"] = string(n.Destination)
+	m["Title"] = string(n.Title)
+	m["LinkType"] = n.LinkType.String()
+	ast.DumpHelper(n, source, level, m, nil)
+}
 
-const (
-	linkTypeExternal linkType = iota
-	linkTypePackage
-	linkTypeInternal
-)
+// Kind implements Node.Kind.
+func (*GnoLink) Kind() ast.NodeKind {
+	return KindGnoLink
+}
 
 // linkTransformer implements ASTTransformer
 type linkTransformer struct{}
 
 // Transform replaces ast.Link nodes with GnoLink nodes in two passes.
 func (t *linkTransformer) Transform(doc *ast.Document, reader text.Reader, pc parser.Context) {
-	url, ok := getUrlFromContext(pc)
+	orig, ok := getUrlFromContext(pc)
 	if !ok {
 		return
 	}
 
-	// First pass: collect all *ast.Link nodes to transform
-	var linkNodes []ast.Node
+	// Traverse through the document and transform link nodes to GnoLink nodes.
 	ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
-		if entering {
-			if _, ok := node.(*ast.Link); ok {
-				linkNodes = append(linkNodes, node)
-			}
+		if !entering {
+			return ast.WalkContinue, nil
 		}
+
+		link, ok := node.(*ast.Link)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+
+		// Create a new GnoLink node wrapping the original link.
+		gnoLink := &GnoLink{Link: link}
+
+		// Replace the original link with the GnoLink wrapper.
+		parent, next := node.Parent(), node.NextSibling()
+		parent.RemoveChild(parent, node)
+		parent.InsertBefore(parent, next, gnoLink)
+
+		// Parse destination URL and check for validity.
+		dest, err := url.Parse(string(link.Destination))
+		if err != nil {
+			gnoLink.LinkType = GnoLinkTypeInvalid
+			return ast.WalkContinue, nil
+		}
+
+		// Detect and set the GnoLink type.
+		gnoLink.GnoURL, gnoLink.LinkType = detectLinkType(dest, &orig)
+
 		return ast.WalkContinue, nil
 	})
+}
 
-	// Second pass: transform and replace collected nodes
-	for _, node := range linkNodes {
-		link := node.(*ast.Link)
-		dest := string(link.Destination)
-
-		linkType, hasHelp, err := detectLinkType(dest, url.Domain, url.Path)
-		if err != nil {
-			continue
+// detectLinkType detects the type of link based on the destination
+func detectLinkType(dest *url.URL, orig *weburl.GnoURL) (*weburl.GnoURL, GnoLinkType) {
+	// Attempt to parse the destination as a GnoURL.
+	target, err := weburl.ParseFromURL(dest)
+	if err != nil {
+		if dest.Scheme == "" {
+			// If there's no scheme, consider it as a relative path.
+			return nil, GnoLinkTypePackage
 		}
+		// Otherwise, treat it as an external URL.
+		return nil, GnoLinkTypeExternal
+	}
 
-		gnoLink := &GnoLink{}
-		gnoLink.Link = *link
-		gnoLink.Metadata = LinkMetadata{
-			LinkType: linkType,
-			HasHelp:  hasHelp,
-		}
+	// Extract domain and namespace from the target.
+	targetDomain := target.Domain
+	targetName := target.Namespace()
 
-		parent := link.Parent()
-		if parent == nil {
-			parent = doc
-		}
-		parent.ReplaceChild(parent, link, gnoLink)
+	switch {
+	case targetDomain != "" && targetDomain != orig.Domain:
+		// External: the domain does not match the origin's domain.
+		return target, GnoLinkTypeExternal
+	case targetName != "" && targetName == orig.Namespace():
+		// Package: the namespace matches the origin's namespace.
+		return target, GnoLinkTypePackage
+	default:
+		// Internal: it's neither external nor a package link.
+		return target, GnoLinkTypeInternal
 	}
 }
 
+// linkRenderer implements NodeRenderer
+type linkRenderer struct{}
+
 // RegisterFuncs registers the renderer functions
 func (r *linkRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
-	reg.Register(ast.KindLink, r.renderLink)
-}
-
-// isSamePackage checks if the link points to the same package
-// - Link is an anchor (starts with #)
-// - Link is relative (no leading / and no protocol -> root link)
-// - Link points to the same package in /r/ path
-// - Link points to the same package in /p/ path
-// - Link points to the same package in /u/ path
-func isSamePackage(dest, pathWithoutR string) bool {
-	return strings.HasPrefix(dest, "#") ||
-		(!strings.HasPrefix(dest, "/") && !strings.Contains(dest, "://")) ||
-		strings.Contains(dest, "/r/"+pathWithoutR) ||
-		strings.Contains(dest, "/p/"+pathWithoutR) ||
-		strings.Contains(dest, "/u/"+pathWithoutR)
-}
-
-// Error messages for invalid link formats
-var (
-	ErrLinkInvalidURL = errors.New("invalid URL format")
-)
-
-var linkTypes = map[linkType]linkTypeInfo{
-	linkTypeExternal: {tooltipExternalLink, iconExternalLink, classLinkExternal},
-	linkTypeInternal: {tooltipInternalLink, iconInternalLink, classLinkInternal},
-	linkTypePackage:  {tooltipTxLink, iconTxLink, classLinkTx},
-}
-
-// linkTypeInfo contains information about a link type
-type linkTypeInfo struct {
-	tooltip string
-	icon    string
-	class   string
+	reg.Register(KindGnoLink, r.renderGnoLink)
 }
 
 // attr represents an HTML attribute
@@ -147,102 +165,103 @@ type attr struct {
 	value string
 }
 
-// writeHTMLTag writes an HTML attribute
+// writeHTMLTag writes an HTML attribute.
+// XXX: We probably want this as a general helper for futur extension.
 func writeHTMLTag(w util.BufWriter, tag string, attrs []attr) {
 	w.WriteString("<" + tag)
 	for _, a := range attrs {
-		w.WriteString(" ") // write a single space
+		w.WriteByte(' ') // write space separator
 		fmt.Fprintf(w, "%s=%q", a.name, a.value)
 	}
-	w.WriteString(">")
+	w.WriteByte('>')
 }
 
-// detectLinkType detects the type of link based on the destination
-func detectLinkType(dest, domain, path string) (linkType, bool, error) {
-	// Extract the package name from the path (e.g., "r/test/foo" -> "test")
-	pathWithoutR := strings.TrimPrefix(path, "/r/")
-	if idx := strings.Index(pathWithoutR, "/"); idx != -1 {
-		pathWithoutR = pathWithoutR[:idx]
-	}
-
-	// Check if the link is external:
-	// - Contains a protocol (e.g., http://, https://)
-	// - Contains a domain different from the current one
-	if strings.Contains(dest, "://") && !strings.Contains(dest, "://"+domain) {
-		return linkTypeExternal, false, nil
-	}
-
-	// Check if the link is a package link
-	if isSamePackage(dest, pathWithoutR) {
-		return linkTypePackage, strings.Contains(dest, "$help"), nil
-	}
-
-	// All other links are internal
-	return linkTypeInternal, strings.Contains(dest, "$help"), nil
+// linkTypeInfo contains information about a link type.
+type linkTypeInfo struct {
+	tooltip string
+	icon    string
+	class   string
 }
 
-// renderLink renders a link node
-func (r *linkRenderer) renderLink(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+var linkTypes = map[GnoLinkType]linkTypeInfo{
+	GnoLinkTypeExternal: {tooltipExternalLink, iconExternalLink, classLinkExternal},
+	GnoLinkTypeInternal: {tooltipInternalLink, iconInternalLink, classLinkInternal},
+	GnoLinkTypePackage:  {tooltipTxLink, iconTxLink, classLinkTx},
+}
+
+// renderGnoLink renders a link node.
+func (r *linkRenderer) renderGnoLink(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	n, ok := node.(*GnoLink)
 	if !ok {
 		return ast.WalkContinue, nil
 	}
 
-	if !entering {
-		// Add the Tx icon span if needed
-		if n.Metadata.HasHelp {
-			txAttrs := []attr{
-				{"class", classLinkTx + " tooltip"},
-				{"data-tooltip", tooltipTxLink},
-			}
-			writeHTMLTag(w, "span", txAttrs)
-			w.WriteString(iconTxLink)
-			w.WriteString("</span>")
+	if n.LinkType == GnoLinkTypeInvalid {
+		if entering {
+			fmt.Fprintf(w, "<!-- invalid link %q -->", n.Destination)
+		}
+		return ast.WalkSkipChildren, nil
+	}
+
+	if entering {
+		// Prepare link attributes with href first.
+		attrs := []attr{{"href", string(n.Destination)}}
+		if n.LinkType == GnoLinkTypeExternal {
+			attrs = append(attrs, attr{"rel", "noopener nofollow ugc"})
+		}
+		if n.Title != nil {
+			attrs = append(attrs, attr{"title", string(n.Title)})
 		}
 
-		// Add external/internal icon span if needed
-		if n.Metadata.LinkType != linkTypePackage {
-			if info, ok := linkTypes[n.Metadata.LinkType]; ok {
-				attrs := []attr{
-					{"class", info.class + " tooltip"},
-					{"data-tooltip", info.tooltip},
-				}
-				writeHTMLTag(w, "span", attrs)
-				w.WriteString(info.icon)
-				w.WriteString("</span>")
-			}
-		}
-
-		w.WriteString("</a>")
+		// Write opening tag <a>.
+		writeHTMLTag(w, "a", attrs)
 		return ast.WalkContinue, nil
 	}
 
-	// Prepare link attributes with href first
-	attrs := []attr{{"href", string(n.Destination)}}
-	if n.Metadata.LinkType == linkTypeExternal {
-		attrs = append(attrs, attr{"rel", "noopener nofollow ugc"})
-	}
-	if n.Title != nil {
-		attrs = append(attrs, attr{"title", string(n.Title)})
+	// Add the Tx icon span if needed.
+	if n.LinkType != GnoLinkTypeExternal &&
+		n.GnoURL != nil && n.GnoURL.WebQuery.Has("help") { // has help webquery
+		writeHTMLTag(w, "span", []attr{
+			{"class", classLinkTx + " tooltip"},
+			{"data-tooltip", tooltipTxLink},
+		})
+		w.WriteString(iconTxLink)
+		w.WriteString("</span>")
 	}
 
-	// Write opening <a> tag
-	writeHTMLTag(w, "a", attrs)
+	// Add external/internal icon span if needed.
+	if n.LinkType != GnoLinkTypePackage {
+		if info, ok := linkTypes[n.LinkType]; ok {
+			writeHTMLTag(w, "span", []attr{
+				{"class", info.class + " tooltip"},
+				{"data-tooltip", info.tooltip},
+			})
+			w.WriteString(info.icon)
+			w.WriteString("</span>")
+		}
+	}
+
+	// Write closing tag <a>.
+	w.WriteString("</a>")
 
 	return ast.WalkContinue, nil
 }
 
+// linkExtension is a Goldmark extension that handles link rendering with special attributes
+// for external, internal, and same-package links.
+type linkExtension struct{}
+
+// Links instance for extending markdown with link functionality
+var Links = &linkExtension{}
+
 // Extend adds the LinkExtension to the provided Goldmark markdown processor
-func (l *LinkExtension) Extend(m goldmark.Markdown) {
+func (l *linkExtension) Extend(m goldmark.Markdown) {
 	m.Parser().AddOptions(parser.WithASTTransformers(
 		util.Prioritized(&linkTransformer{}, 500),
 	))
 
 	// Register our renderer with a higher priority than the default renderer
 	m.Renderer().AddOptions(renderer.WithNodeRenderers(
-		util.Prioritized(&linkRenderer{}, 0), // Priority 0 is higher than default
+		util.Prioritized(&linkRenderer{}, 500), // Priority 0 is higher than default
 	))
 }
-
-// Links instance for extending markdown with link functionality
-var Links = &LinkExtension{}

--- a/gno.land/pkg/gnoweb/markdown/ext_test.go
+++ b/gno.land/pkg/gnoweb/markdown/ext_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/parser"
-	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/text"
-	"github.com/yuin/goldmark/util"
 )
 
 const testdataDir = "golden"
@@ -31,23 +29,15 @@ func testGoldmarkOutput(t *testing.T, nameIn string, input []byte) (string, []by
 	require.Greater(t, len(name), 0, "txtar file name cannot be empty")
 
 	// Create a test URL for the context
-	testURL := weburl.GnoURL{
-		Domain: "gno.land",
-		Path:   "/r/test",
-	}
+	gnourl, err := weburl.Parse("https://gno.land/r/test")
+	require.NoError(t, err)
 
 	// Create parser context with the test URL
-	ctxOpts := parser.WithContext(NewGnoParserContext(testURL))
+	ctxOpts := parser.WithContext(NewGnoParserContext(gnourl))
 
 	// Create markdown processor with extensions and renderer options
-	m := goldmark.New(
-		goldmark.WithRendererOptions(
-			renderer.WithNodeRenderers(util.Prioritized(&linkRenderer{}, 500)),
-		),
-	)
-
-	// Add extensions with context
-	NewGnoExtension(testURL).Extend(m)
+	m := goldmark.New()
+	GnoExtension.Extend(m)
 
 	// Parse markdown input with context
 	node := m.Parser().Parse(text.NewReader(input), ctxOpts)

--- a/gno.land/pkg/gnoweb/markdown/golden/ext_link/iniline.md.txtar
+++ b/gno.land/pkg/gnoweb/markdown/golden/ext_link/iniline.md.txtar
@@ -3,6 +3,9 @@ Lorem ipsum dolor sit [external](https://example.com) consectetur adipiscing eli
 Vivamus nibh dui, finibus [internal](/r/other/realm) quis placerat et, laoreet ut est.
 Nam id ipsum faucibus [package](/r/test/mypackage/realm) ultrices eros at.
 
+Nam id ipsum *faucibus* *[italic](/r/test/mypackage/realm)* ultrices eros at.
+Nam id ipsum faucibus __[italic](/r/test/mypackage/realm)__ ultrices eros at.
+
 ## Inline title [internal](/r/other/realm)
 
 - level 1 [internal1](/r/other1/realm)
@@ -13,6 +16,8 @@ Nam id ipsum faucibus [package](/r/test/mypackage/realm) ultrices eros at.
 <p>Lorem ipsum dolor sit <a href="https://example.com" rel="noopener nofollow ugc">external<span class="link-external tooltip" data-tooltip="External link">↗</span></a> consectetur adipiscing elit.
 Vivamus nibh dui, finibus <a href="/r/other/realm">internal<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a> quis placerat et, laoreet ut est.
 Nam id ipsum faucibus <a href="/r/test/mypackage/realm">package</a> ultrices eros at.</p>
+<p>Nam id ipsum <em>faucibus</em> <em><a href="/r/test/mypackage/realm">italic</a></em> ultrices eros at.
+Nam id ipsum faucibus <strong><a href="/r/test/mypackage/realm">italic</a></strong> ultrices eros at.</p>
 <h2>Inline title <a href="/r/other/realm">internal<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a></h2>
 <ul>
 <li>level 1 <a href="/r/other1/realm">internal1<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a>

--- a/gno.land/pkg/gnoweb/markdown/golden/ext_link/iniline_link.md.txtar
+++ b/gno.land/pkg/gnoweb/markdown/golden/ext_link/iniline_link.md.txtar
@@ -1,0 +1,27 @@
+-- input.md --
+Lorem ipsum dolor sit [external](https://example.com) consectetur adipiscing elit.
+Vivamus nibh dui, finibus [internal](/r/other/realm) quis placerat et, laoreet ut est.
+Nam id ipsum faucibus [package](/r/test/mypackage/realm) ultrices eros at.
+
+## Inline title [internal](/r/other/realm)
+
+- level 1 [internal1](/r/other1/realm)
+  - level 2 [internal2](/r/other2/realm)
+    - level 3 [internal3](/r/other3/realm)
+
+-- output.html --
+<p>Lorem ipsum dolor sit <a href="https://example.com" rel="noopener nofollow ugc">external<span class="link-external tooltip" data-tooltip="External link">↗</span></a> consectetur adipiscing elit.
+Vivamus nibh dui, finibus <a href="/r/other/realm">internal<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a> quis placerat et, laoreet ut est.
+Nam id ipsum faucibus <a href="/r/test/mypackage/realm">package</a> ultrices eros at.</p>
+<h2>Inline title <a href="/r/other/realm">internal<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a></h2>
+<ul>
+<li>level 1 <a href="/r/other1/realm">internal1<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a>
+<ul>
+<li>level 2 <a href="/r/other2/realm">internal2<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a>
+<ul>
+<li>level 3 <a href="/r/other3/realm">internal3<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>

--- a/gno.land/pkg/gnoweb/markdown/golden/ext_link/inline.md.txtar
+++ b/gno.land/pkg/gnoweb/markdown/golden/ext_link/inline.md.txtar
@@ -1,0 +1,31 @@
+-- input.md --
+Lorem ipsum dolor sit [external](https://example.com) consectetur adipiscing elit.
+Vivamus nibh dui, finibus [internal](/r/other/realm) quis placerat et, laoreet ut est.
+Nam id ipsum faucibus [package](/r/test/mypackage/realm) ultrices eros at.
+
+Nam id ipsum faucibus *[italic](/r/test/mypackage/realm)* ultrices eros at.
+Nam id ipsum faucibus **[bold](/r/test/mypackage/realm)** ultrices eros at.
+
+
+## Inline title [internal](/r/other/realm)
+
+- level 1 [internal1](/r/other1/realm)
+  - level 2 [internal2](/r/other2/realm)
+    - level 3 [internal3](/r/other3/realm)
+
+-- output.html --
+<p>Lorem ipsum dolor sit <a href="https://example.com" rel="noopener nofollow ugc">external<span class="link-external tooltip" data-tooltip="External link">↗</span></a> consectetur adipiscing elit.
+Vivamus nibh dui, finibus <a href="/r/other/realm">internal<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a> quis placerat et, laoreet ut est.
+Nam id ipsum faucibus <a href="/r/test/mypackage/realm">package</a> ultrices eros at.</p>
+<h2>Inline title <a href="/r/other/realm">internal<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a></h2>
+<ul>
+<li>level 1 <a href="/r/other1/realm">internal1<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a>
+<ul>
+<li>level 2 <a href="/r/other2/realm">internal2<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a>
+<ul>
+<li>level 3 <a href="/r/other3/realm">internal3<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>

--- a/gno.land/pkg/gnoweb/markdown/golden/ext_link/inline.md.txtar
+++ b/gno.land/pkg/gnoweb/markdown/golden/ext_link/inline.md.txtar
@@ -17,6 +17,8 @@ Nam id ipsum faucibus **[bold](/r/test/mypackage/realm)** ultrices eros at.
 <p>Lorem ipsum dolor sit <a href="https://example.com" rel="noopener nofollow ugc">external<span class="link-external tooltip" data-tooltip="External link">↗</span></a> consectetur adipiscing elit.
 Vivamus nibh dui, finibus <a href="/r/other/realm">internal<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a> quis placerat et, laoreet ut est.
 Nam id ipsum faucibus <a href="/r/test/mypackage/realm">package</a> ultrices eros at.</p>
+<p>Nam id ipsum faucibus <em><a href="/r/test/mypackage/realm">italic</a></em> ultrices eros at.
+Nam id ipsum faucibus <strong><a href="/r/test/mypackage/realm">bold</a></strong> ultrices eros at.</p>
 <h2>Inline title <a href="/r/other/realm">internal<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a></h2>
 <ul>
 <li>level 1 <a href="/r/other1/realm">internal1<span class="link-internal tooltip" data-tooltip="Cross package link">↔</span></a>

--- a/gno.land/pkg/gnoweb/markdown/golden/ext_link/invalid.md.txtar
+++ b/gno.land/pkg/gnoweb/markdown/golden/ext_link/invalid.md.txtar
@@ -6,5 +6,8 @@
 [Invalid dest](>https://example.com)
 
 -- output.html --
-<p><!-- invalid link "https://example.com|" -->
-<!-- invalid link "https://example.com\\n" --></p>
+<p><!-- invalid link -->
+<!-- invalid link -->
+<a href="https://example.com" rel="noopener nofollow ugc">Invalid html tag <!-- raw HTML omitted --><span class="link-external tooltip" data-tooltip="External link">↗</span></a>
+<a href="https://example.com" rel="noopener nofollow ugc" title="\\\"<div>">Invalid html tag 2<span class="link-external tooltip" data-tooltip="External link">↗</span></a>
+<!-- invalid link --></p>

--- a/gno.land/pkg/gnoweb/markdown/golden/ext_link/invalid.md.txtar
+++ b/gno.land/pkg/gnoweb/markdown/golden/ext_link/invalid.md.txtar
@@ -1,0 +1,6 @@
+-- input.md --
+[Invalid char](https://example.com|)
+[Invalid new line](https://example.com\n)
+-- output.html --
+<p><!-- invalid link "https://example.com|" -->
+<!-- invalid link "https://example.com\\n" --></p>

--- a/gno.land/pkg/gnoweb/markdown/golden/ext_link/invalid.md.txtar
+++ b/gno.land/pkg/gnoweb/markdown/golden/ext_link/invalid.md.txtar
@@ -1,6 +1,10 @@
 -- input.md --
 [Invalid char](https://example.com|)
 [Invalid new line](https://example.com\n)
+[Invalid html tag <div>](https://example.com)
+[Invalid html tag 2](https://example.com "\"<div>")
+[Invalid dest](>https://example.com)
+
 -- output.html --
 <p><!-- invalid link "https://example.com|" -->
 <!-- invalid link "https://example.com\\n" --></p>

--- a/gno.land/pkg/gnoweb/webclient.go
+++ b/gno.land/pkg/gnoweb/webclient.go
@@ -30,7 +30,7 @@ type WebClient interface {
 	// RenderRealm renders the content of a realm from a given path and
 	// arguments into the giver `writer`. The method should ensures the rendered
 	// content is safely handled and formatted.
-	RenderRealm(w io.Writer, u weburl.GnoURL) (*RealmMeta, error)
+	RenderRealm(w io.Writer, u *weburl.GnoURL) (*RealmMeta, error)
 
 	// SourceFile fetches and writes the source file from a given
 	// package path and file name. The method should ensures the source

--- a/gno.land/pkg/gnoweb/webclient_html.go
+++ b/gno.land/pkg/gnoweb/webclient_html.go
@@ -182,7 +182,7 @@ func (s *HTMLWebClient) RenderRealm(w io.Writer, u *weburl.GnoURL) (*RealmMeta, 
 	const qpath = "vm/qrender"
 
 	pkgPath := strings.Trim(u.Path, "/")
-	data := fmt.Sprintf("%s/%s:%s", s.domain, pkgPath, u.Args)
+	data := fmt.Sprintf("%s/%s:%s", s.domain, pkgPath, u.EncodeArgs())
 
 	rawres, err := s.query(qpath, []byte(data))
 	if err != nil {

--- a/gno.land/pkg/gnoweb/webclient_html.go
+++ b/gno.land/pkg/gnoweb/webclient_html.go
@@ -52,7 +52,8 @@ func NewDefaultHTMLWebClientConfig(client *client.RPCClient) *HTMLWebClientConfi
 			),
 			extension.Strikethrough,
 			extension.Table,
-			md.Links,
+
+			md.GnoExtension,
 		),
 	}
 
@@ -177,7 +178,7 @@ func (s *HTMLWebClient) Sources(path string) ([]string, error) {
 // RenderRealm renders the content of a realm from a given path
 // and arguments into the provided writer. It uses Goldmark for
 // Markdown processing to generate HTML content.
-func (s *HTMLWebClient) RenderRealm(w io.Writer, u weburl.GnoURL) (*RealmMeta, error) {
+func (s *HTMLWebClient) RenderRealm(w io.Writer, u *weburl.GnoURL) (*RealmMeta, error) {
 	const qpath = "vm/qrender"
 
 	pkgPath := strings.Trim(u.Path, "/")

--- a/gno.land/pkg/gnoweb/webclient_mock.go
+++ b/gno.land/pkg/gnoweb/webclient_mock.go
@@ -34,7 +34,7 @@ func NewMockWebClient(pkgs ...*MockPackage) *MockWebClient {
 }
 
 // RenderRealm simulates rendering a package by writing its content to the writer.
-func (m *MockWebClient) RenderRealm(w io.Writer, u weburl.GnoURL) (*RealmMeta, error) {
+func (m *MockWebClient) RenderRealm(w io.Writer, u *weburl.GnoURL) (*RealmMeta, error) {
 	pkg, exists := m.Packages[u.Path]
 	if !exists {
 		return nil, ErrClientPathNotFound

--- a/gno.land/pkg/gnoweb/weburl/url.go
+++ b/gno.land/pkg/gnoweb/weburl/url.go
@@ -12,9 +12,6 @@ import (
 
 var ErrURLInvalidPath = errors.New("invalid path")
 
-// rePkgOrRealmPath matches and validates a flexible path.
-var rePkgOrRealmPath = regexp.MustCompile(`^/[a-z0-9_/]*$`)
-
 // GnoURL decomposes the parts of an URL to query a realm.
 type GnoURL struct {
 	// Example full path:
@@ -156,6 +153,9 @@ func (gnoURL GnoURL) IsDir() bool {
 		len(gnoURL.Path) > 0 && gnoURL.Path[len(gnoURL.Path)-1] == '/'
 }
 
+// rePkgOrRealmPath matches and validates a flexible path.
+var rePkgOrRealmPath = regexp.MustCompile(`^/[a-z][a-z0-9_/]*$`)
+
 func (gnoURL GnoURL) IsValid() bool {
 	return rePkgOrRealmPath.MatchString(gnoURL.Path)
 }
@@ -205,10 +205,6 @@ func ParseFromURL(u *url.URL) (*GnoURL, error) {
 		if i := strings.LastIndexByte(upath, '/'); i > 0 {
 			upath = upath[:i]
 		}
-	}
-
-	if !rePkgOrRealmPath.MatchString(upath) {
-		return nil, fmt.Errorf("%w: %q", ErrURLInvalidPath, upath)
 	}
 
 	webquery := url.Values{}

--- a/gno.land/pkg/gnoweb/weburl/url.go
+++ b/gno.land/pkg/gnoweb/weburl/url.go
@@ -207,6 +207,10 @@ func ParseFromURL(u *url.URL) (*GnoURL, error) {
 		}
 	}
 
+	if !rePkgPath.MatchString(upath) {
+		return nil, fmt.Errorf("%w: %q", ErrURLInvalidPath, upath)
+	}
+
 	webquery := url.Values{}
 	if len(webargs) > 0 {
 		var parseErr error

--- a/gno.land/pkg/gnoweb/weburl/url.go
+++ b/gno.land/pkg/gnoweb/weburl/url.go
@@ -153,11 +153,11 @@ func (gnoURL GnoURL) IsDir() bool {
 		len(gnoURL.Path) > 0 && gnoURL.Path[len(gnoURL.Path)-1] == '/'
 }
 
-// rePkgOrRealmPath matches and validates a flexible path.
-var rePkgOrRealmPath = regexp.MustCompile(`^/[a-z][a-z0-9_/]*$`)
+// rePkgPath matches and validates a path.
+var rePkgPath = regexp.MustCompile(`^/[a-z0-9_/]*$`)
 
-func (gnoURL GnoURL) IsValid() bool {
-	return rePkgOrRealmPath.MatchString(gnoURL.Path)
+func (gnoURL GnoURL) IsValidPath() bool {
+	return rePkgPath.MatchString(gnoURL.Path)
 }
 
 var reNamespace = regexp.MustCompile(`^/[a-z]/[a-z][a-z0-9_/]*$`)

--- a/gno.land/pkg/gnoweb/weburl/url_test.go
+++ b/gno.land/pkg/gnoweb/weburl/url_test.go
@@ -10,18 +10,12 @@ import (
 
 func TestParseGnoURL(t *testing.T) {
 	testCases := []struct {
-		Name     string
-		Input    string
-		Expected *GnoURL
-		Err      error
+		Name          string
+		Input         string
+		Expected      *GnoURL
+		Err           error
+		IsInvalidPath bool
 	}{
-		{
-			Name:     "malformed url",
-			Input:    "https://gno.land/r/dem)o:$?",
-			Expected: nil,
-			Err:      ErrURLInvalidPath,
-		},
-
 		{
 			Name:  "simple",
 			Input: "https://gno.land/r/simple/test",
@@ -250,6 +244,13 @@ func TestParseGnoURL(t *testing.T) {
 				Domain:   "gno.land",
 			},
 		},
+
+		{
+			Name:     "invalid path",
+			Input:    "https://gno.land/r/dem)o:$?",
+			Expected: nil,
+			Err:      ErrURLInvalidPath,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -269,6 +270,61 @@ func TestParseGnoURL(t *testing.T) {
 			}
 
 			assert.Equal(t, tc.Expected, result)
+		})
+	}
+}
+
+func TestIsValidPath(t *testing.T) {
+	testCases := []struct {
+		Path  string
+		Valid bool
+	}{
+		{Path: "/", Valid: true},
+		{Path: "/r/valid", Valid: true},
+		{Path: "/p/abc_123", Valid: true},
+		{Path: "/r/demo/users/", Valid: true},
+		{Path: "/R/invalid", Valid: false},
+		{Path: "/r/invalid@path", Valid: false},
+		{Path: "r/invalid", Valid: false},
+		{Path: "", Valid: false},
+		{Path: "/r/valid/path_with/underscores", Valid: true},
+		{Path: "/r/", Valid: true},
+		{Path: "/r/with space", Valid: false},
+		{Path: "/r/hyphen-invalid", Valid: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Path, func(t *testing.T) {
+			gnoURL := GnoURL{Path: tc.Path}
+			assert.Equal(t, tc.Valid, gnoURL.IsValidPath())
+		})
+	}
+}
+
+func TestNamespace(t *testing.T) {
+	testCases := []struct {
+		Path     string
+		Expected string
+	}{
+		{Path: "/r/test", Expected: "test"},
+		{Path: "/r/test/foo", Expected: "test"},
+		{Path: "/p/another", Expected: "another"},
+		{Path: "/r/123invalid", Expected: ""},
+		{Path: "/r/TEST", Expected: ""},
+		{Path: "/x/ns", Expected: "ns"},
+		{Path: "/r/a", Expected: "a"},
+		{Path: "/r/a1", Expected: "a1"},
+		{Path: "/r/a_b/c", Expected: "a_b"},
+		{Path: "/invalidpath", Expected: ""},
+		{Path: "/r/", Expected: ""},
+		{Path: "/r/a-b/c", Expected: ""},
+		{Path: "/r/valid-ns", Expected: ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Path, func(t *testing.T) {
+			gnoURL := GnoURL{Path: tc.Path}
+			assert.Equal(t, tc.Expected, gnoURL.Namespace())
 		})
 	}
 }

--- a/gno.land/pkg/gnoweb/weburl/url_test.go
+++ b/gno.land/pkg/gnoweb/weburl/url_test.go
@@ -518,7 +518,7 @@ func TestEncode(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			result := tc.GnoURL.Encode(tc.EncodeFlags)
-			require.True(t, tc.GnoURL.IsValid(), "gno url is not valid")
+			require.True(t, tc.GnoURL.IsValidPath(), "gno url is not valid")
 			assert.Equal(t, tc.Expected, result)
 		})
 	}

--- a/gno.land/pkg/gnoweb/weburl/url_test.go
+++ b/gno.land/pkg/gnoweb/weburl/url_test.go
@@ -259,7 +259,7 @@ func TestParseGnoURL(t *testing.T) {
 			u, err := url.Parse(tc.Input)
 			require.NoError(t, err)
 
-			result, err := ParseGnoURL(u, "gno.land")
+			result, err := ParseFromURL(u)
 			if tc.Err == nil {
 				require.NoError(t, err)
 				t.Logf("encoded web path: %q", result.EncodeWebURL())


### PR DESCRIPTION
cowork on Link UI

- Rollback on minimal function prototype
- Improve transform performance with a unique iteration
- Centralize logic and make parsing more robust using `url` and `weburl` packages
- Add invalid path
- Fix some `nil` pointer executions
- Normalize ext prefix on exposed symbol
- Fix tests + lint

Still miss some tests on creating more complex ast with children and link within paragraph and list